### PR TITLE
Silence `this.pickFiles` deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 var path = require('path');
+var Funnel = require('broccoli-funnel');
 
 module.exports = {
   name: 'ember-neat',
@@ -8,7 +9,7 @@ module.exports = {
   },
   treeForStyles: function() {
     var neatPath = path.join(this.app.bowerDirectory, 'neat', 'app/assets/stylesheets');
-    var neatTree = this.pickFiles(this.treeGenerator(neatPath), {
+    var neatTree = new Funnel(this.treeGenerator(neatPath), {
       srcDir: '/',
       destDir: '/app/styles'
     });

--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
   ],
   "ember-addon": {
     "configPath": "tests/dummy/config"
+  },
+  "dependencies": {
+    "broccoli-funnel": "^0.2.3"
   }
 }


### PR DESCRIPTION
> [Deprecated] this.pickFiles is deprecated, please use broccoli-funnel directly instead  [addon: ember-neat]

Use `broccoli-funnel`
