### PR TITLE
Merges in bourbon before neat: fixes #6

### DIFF
--- a/blueprints/ember-cli-neat/files/app/styles/app.scss
+++ b/blueprints/ember-cli-neat/files/app/styles/app.scss
@@ -1,1 +1,2 @@
+@import "bourbon";
 @import "neat";

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 var path = require('path');
 var Funnel = require('broccoli-funnel');
+var MergeTrees = require('broccoli-merge-trees');
 
 module.exports = {
   name: 'ember-neat',
@@ -8,11 +9,16 @@ module.exports = {
     return path.join(__dirname, 'blueprints');
   },
   treeForStyles: function() {
+    var bourbonPath = path.join(this.app.bowerDirectory, 'bourbon', 'app/assets/stylesheets');
+    var bourbonTree = new Funnel(this.treeGenerator(bourbonPath), {
+      srcDir: '/',
+      destDir: '/app/styles'
+    });
     var neatPath = path.join(this.app.bowerDirectory, 'neat', 'app/assets/stylesheets');
     var neatTree = new Funnel(this.treeGenerator(neatPath), {
       srcDir: '/',
       destDir: '/app/styles'
     });
-    return neatTree;
+    return new MergeTrees([bourbonTree, neatPath]);
   }
 };

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "configPath": "tests/dummy/config"
   },
   "dependencies": {
+    "broccoli-merge-trees": "^0.2.3",
     "broccoli-funnel": "^0.2.3"
   }
 }


### PR DESCRIPTION
Neat requires bourbon to be installed.

This should merge trees with Bourbon so that this is the only package required and does not overwrite `@import "bourbon";`
